### PR TITLE
feat: add funding.yml file

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,4 @@
+# These are supported funding model platforms
+
+github: [jamilservicos]
+patreon: jamilservices


### PR DESCRIPTION
Add the .github/FUNDING.yml file to support funding platforms.
The file contains the supported funding model platforms: github (jamilservicos) and patreon (jamilservices).